### PR TITLE
Enhance control panel UX and simplify preview

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@motionone/react": "^10.16.1",
     "colorjs.io": "^0.4.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
@@ -23,7 +22,6 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",
-    "@tailwindcss/postcss": "^4.1.7",
     "@testing-library/react": "^14.0.0",
     "@types/react": "^18.0.37",
     "@types/react-dom": "^18.0.11",

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,7 +1,4 @@
 module.exports = {
-  plugins: [
-    require('@tailwindcss/postcss'),
-    require('autoprefixer')
-  ]
+  plugins: [require('tailwindcss'), require('autoprefixer')]
 };
 

--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -1,4 +1,10 @@
-import { FiCopy, FiToggleLeft, FiToggleRight } from 'react-icons/fi';
+import {
+  FiCopy,
+  FiToggleLeft,
+  FiToggleRight,
+  FiRefreshCcw
+} from 'react-icons/fi';
+import { useNeumorph } from '../hooks/useNeumorph';
 
 interface Props {
   color: string;
@@ -25,8 +31,20 @@ export default function ControlPanel({
   isPressed,
   onToggle
 }: Props) {
+  const { raisedShadow, insetShadow } = useNeumorph(color, depth);
+
   const copy = () => {
-    navigator.clipboard.writeText(document.documentElement.style.cssText);
+    const shadow = isPressed ? insetShadow : raisedShadow;
+    const css = `box-shadow: ${shadow}; border-radius: ${radius}px;`;
+    navigator.clipboard.writeText(css);
+  };
+
+  const reset = () => {
+    onColorChange('#cccccc');
+    onDepthChange(6);
+    onSizeChange(150);
+    onRadiusChange(12);
+    if (isPressed) onToggle();
   };
 
   return (
@@ -82,6 +100,12 @@ export default function ControlPanel({
         className="flex items-center gap-2 border rounded px-2 py-1"
       >
         <FiCopy /> Copy CSS
+      </button>
+      <button
+        onClick={reset}
+        className="flex items-center gap-2 border rounded px-2 py-1"
+      >
+        <FiRefreshCcw /> Reset
       </button>
     </div>
   );

--- a/src/components/PreviewCard.tsx
+++ b/src/components/PreviewCard.tsx
@@ -1,4 +1,3 @@
-import { motion } from '@motionone/react';
 import { useNeumorph } from '../hooks/useNeumorph';
 import { CSSProperties } from 'react';
 
@@ -25,6 +24,8 @@ export default function PreviewCard({
     width: size,
     height: size,
     borderRadius: radius,
+    transition: 'box-shadow 0.2s ease',
+    boxShadow: isPressed ? insetShadow : raisedShadow,
     '--neu-h': h,
     '--neu-s': `${s}%`,
     '--neu-l': `${l}%`,
@@ -48,17 +49,16 @@ export default function PreviewCard({
   };
 
   return (
-    <motion.div
+    <div
       data-testid="card"
       style={style}
       onClick={onToggle}
       onPointerDown={handlePointerDown}
       onPointerUp={handlePointerUp}
-      animate={{ boxShadow: isPressed ? insetShadow : raisedShadow }}
       className="shadow-neumorph flex items-center justify-center select-none"
     >
       {isPressed ? 'Pressed' : 'Raised'}
-    </motion.div>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary
- enrich the control panel with a reset button
- copy the actual box shadow CSS instead of global styles
- drop `@motionone/react` animations and use simple CSS transitions
- simplify PostCSS plugins

## Testing
- `pnpm run lint`
- `pnpm run test` *(fails: esbuild platform mismatch)*
