### PR TITLE
Modernize UI using Tailwind shadcn styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -6,9 +6,10 @@
     <meta name="color-scheme" content="light dark" />
     <title>Neumorph Maker Pro</title>
   </head>
-  <body>
+  <body
+    class="min-h-screen bg-background font-sans antialiased text-foreground"
+  >
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>
-

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,7 @@ export default function App() {
   const [isPressed, setIsPressed] = useState(false);
 
   return (
-    <div className="flex flex-col md:flex-row gap-4 p-4">
+    <div className="container mx-auto flex flex-col md:flex-row gap-4 p-4">
       <ControlPanel
         color={baseColor}
         onColorChange={setBaseColor}
@@ -35,4 +35,3 @@ export default function App() {
     </div>
   );
 }
-

--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -5,6 +5,10 @@ import {
   FiRefreshCcw
 } from 'react-icons/fi';
 import { useNeumorph } from '../hooks/useNeumorph';
+import { Button } from './ui/Button';
+import { Input } from './ui/Input';
+import { Slider } from './ui/Slider';
+import { Label } from './ui/Label';
 
 interface Props {
   color: string;
@@ -49,65 +53,56 @@ export default function ControlPanel({
 
   return (
     <div className="flex flex-col gap-4 w-full md:w-1/3">
-      <label className="flex items-center gap-2">
-        <span>Color</span>
-        <input
+      <div className="flex items-center gap-2">
+        <Label htmlFor="color">Color</Label>
+        <Input
+          id="color"
           type="color"
           value={color}
           onChange={(e) => onColorChange(e.target.value)}
-          className="border rounded"
+          className="h-8 w-8 p-0 border"
         />
-      </label>
-      <label className="flex items-center gap-2">
-        <span>Depth</span>
-        <input
-          type="range"
-          min="1"
-          max="20"
+      </div>
+      <div className="flex items-center gap-2">
+        <Label htmlFor="depth">Depth</Label>
+        <Slider
+          id="depth"
+          min={1}
+          max={20}
           value={depth}
           onChange={(e) => onDepthChange(Number(e.target.value))}
         />
-      </label>
-      <label className="flex items-center gap-2">
-        <span>Size</span>
-        <input
-          type="range"
-          min="100"
-          max="300"
+      </div>
+      <div className="flex items-center gap-2">
+        <Label htmlFor="size">Size</Label>
+        <Slider
+          id="size"
+          min={100}
+          max={300}
           value={size}
           onChange={(e) => onSizeChange(Number(e.target.value))}
         />
-      </label>
-      <label className="flex items-center gap-2">
-        <span>Radius</span>
-        <input
-          type="range"
-          min="0"
-          max="50"
+      </div>
+      <div className="flex items-center gap-2">
+        <Label htmlFor="radius">Radius</Label>
+        <Slider
+          id="radius"
+          min={0}
+          max={50}
           value={radius}
           onChange={(e) => onRadiusChange(Number(e.target.value))}
         />
-      </label>
-      <button
-        onClick={onToggle}
-        className="flex items-center gap-2 border rounded px-2 py-1"
-      >
+      </div>
+      <Button onClick={onToggle} className="flex items-center gap-2">
         {isPressed ? <FiToggleRight /> : <FiToggleLeft />}
         Toggle Pressed
-      </button>
-      <button
-        onClick={copy}
-        className="flex items-center gap-2 border rounded px-2 py-1"
-      >
+      </Button>
+      <Button onClick={copy} className="flex items-center gap-2">
         <FiCopy /> Copy CSS
-      </button>
-      <button
-        onClick={reset}
-        className="flex items-center gap-2 border rounded px-2 py-1"
-      >
+      </Button>
+      <Button onClick={reset} className="flex items-center gap-2">
         <FiRefreshCcw /> Reset
-      </button>
+      </Button>
     </div>
   );
 }
-

--- a/src/components/PreviewCard.tsx
+++ b/src/components/PreviewCard.tsx
@@ -37,9 +37,9 @@ export default function PreviewCard({
 
   const handlePointerDown = () => {
     timeout = setTimeout(() => {
-      navigator.clipboard.writeText(`box-shadow: ${
-        isPressed ? insetShadow : raisedShadow
-      };`);
+      navigator.clipboard.writeText(
+        `box-shadow: ${isPressed ? insetShadow : raisedShadow};`
+      );
     }, 600);
   };
 
@@ -55,10 +55,9 @@ export default function PreviewCard({
       onClick={onToggle}
       onPointerDown={handlePointerDown}
       onPointerUp={handlePointerUp}
-      className="shadow-neumorph flex items-center justify-center select-none"
+      className="shadow-neumorph flex items-center justify-center select-none bg-background text-foreground"
     >
       {isPressed ? 'Pressed' : 'Raised'}
     </div>
   );
 }
-

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,0 +1,16 @@
+import { cn } from '@/lib/utils';
+import { ButtonHTMLAttributes } from 'react';
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {}
+
+export function Button({ className, ...props }: ButtonProps) {
+  return (
+    <button
+      className={cn(
+        'inline-flex items-center justify-center rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:opacity-50',
+        className
+      )}
+      {...props}
+    />
+  );
+}

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -1,0 +1,21 @@
+import { cn } from '@/lib/utils';
+import { forwardRef, InputHTMLAttributes } from 'react';
+
+export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {}
+
+export const Input = forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          'flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+Input.displayName = 'Input';

--- a/src/components/ui/Label.tsx
+++ b/src/components/ui/Label.tsx
@@ -1,0 +1,16 @@
+import { cn } from '@/lib/utils';
+import { LabelHTMLAttributes } from 'react';
+
+export interface LabelProps extends LabelHTMLAttributes<HTMLLabelElement> {}
+
+export function Label({ className, ...props }: LabelProps) {
+  return (
+    <label
+      className={cn(
+        'text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70',
+        className
+      )}
+      {...props}
+    />
+  );
+}

--- a/src/components/ui/Slider.tsx
+++ b/src/components/ui/Slider.tsx
@@ -1,0 +1,14 @@
+import { cn } from '@/lib/utils';
+import { InputHTMLAttributes } from 'react';
+
+export interface SliderProps extends InputHTMLAttributes<HTMLInputElement> {}
+
+export function Slider({ className, ...props }: SliderProps) {
+  return (
+    <input
+      type="range"
+      className={cn('w-full cursor-pointer accent-primary', className)}
+      {...props}
+    />
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -2,3 +2,24 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer base {
+  :root {
+    --background: 0 0% 100%;
+    --foreground: 222.2 84% 4.9%;
+    --primary: 222.2 47.4% 11.2%;
+    --primary-foreground: 210 40% 98%;
+    --secondary: 210 40% 96.1%;
+    --secondary-foreground: 222.2 47.4% 11.2%;
+    --ring: 222.2 84% 4.9%;
+    --radius: 0.5rem;
+  }
+  .dark {
+    --background: 222.2 84% 4.9%;
+    --foreground: 210 40% 98%;
+    --primary: 210 40% 98%;
+    --primary-foreground: 222.2 47.4% 11.2%;
+    --secondary: 222.2 47.4% 11.2%;
+    --secondary-foreground: 210 40% 98%;
+    --ring: 215 20.2% 65.1%;
+  }
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,3 @@
+export function cn(...classes: (string | undefined | null | false)[]): string {
+  return classes.filter(Boolean).join(' ');
+}

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,9 +1,34 @@
 const plugin = require('tailwindcss/plugin');
 
 module.exports = {
+  darkMode: 'class',
   content: ['./index.html', './src/**/*.{ts,tsx}'],
   theme: {
+    container: {
+      center: true,
+      padding: '2rem'
+    },
     extend: {
+      colors: {
+        border: 'hsl(var(--border))',
+        input: 'hsl(var(--input))',
+        ring: 'hsl(var(--ring))',
+        background: 'hsl(var(--background))',
+        foreground: 'hsl(var(--foreground))',
+        primary: {
+          DEFAULT: 'hsl(var(--primary))',
+          foreground: 'hsl(var(--primary-foreground))'
+        },
+        secondary: {
+          DEFAULT: 'hsl(var(--secondary))',
+          foreground: 'hsl(var(--secondary-foreground))'
+        }
+      },
+      borderRadius: {
+        lg: 'var(--radius)',
+        md: 'calc(var(--radius) - 2px)',
+        sm: 'calc(var(--radius) - 4px)'
+      },
       boxShadow: {
         neumorph: 'var(--neu-raised)',
         'neumorph-inset': 'var(--neu-inset)'
@@ -19,4 +44,3 @@ module.exports = {
     })
   ]
 };
-


### PR DESCRIPTION
## Summary
- add utility `cn` for className merging
- implement basic shadcn-style UI components (Button, Input, Label, Slider)
- use these components in `ControlPanel`
- style `PreviewCard` and the page with new design tokens
- update Tailwind configuration with shadcn tokens

## Testing
- `pnpm run lint`
- `pnpm run test` *(fails: esbuild platform mismatch)*