### PR TITLE
Add Shadcn-style button

### DIFF
--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -4,6 +4,7 @@ import {
   FiToggleRight,
   FiRefreshCcw
 } from 'react-icons/fi';
+import Button from './ui/Button';
 import { useNeumorph } from '../hooks/useNeumorph';
 
 interface Props {
@@ -56,7 +57,7 @@ export default function ControlPanel({
           type="color"
           value={color}
           onChange={(e) => onColorChange(e.target.value)}
-          className="border rounded"
+          className="h-8 w-8 rounded-md border border-slate-200"
         />
         <span className="ml-2 text-xs font-mono">{color}</span>
       </label>
@@ -69,6 +70,7 @@ export default function ControlPanel({
           max="20"
           value={depth}
           onChange={(e) => onDepthChange(Number(e.target.value))}
+          className="flex-1 accent-slate-900"
         />
         <span className="ml-2 text-xs font-mono">{depth}px</span>
       </label>
@@ -81,6 +83,7 @@ export default function ControlPanel({
           max="300"
           value={size}
           onChange={(e) => onSizeChange(Number(e.target.value))}
+          className="flex-1 accent-slate-900"
         />
         <span className="ml-2 text-xs font-mono">{size}px</span>
       </label>
@@ -93,28 +96,20 @@ export default function ControlPanel({
           max="50"
           value={radius}
           onChange={(e) => onRadiusChange(Number(e.target.value))}
+          className="flex-1 accent-slate-900"
         />
         <span className="ml-2 text-xs font-mono">{radius}px</span>
       </label>
-      <button
-        onClick={onToggle}
-        className="flex items-center gap-2 border rounded px-2 py-1"
-      >
+      <Button onClick={onToggle} className="flex items-center gap-2" variant="outline">
         {isPressed ? <FiToggleRight /> : <FiToggleLeft />}
         Toggle Pressed
-      </button>
-      <button
-        onClick={copy}
-        className="flex items-center gap-2 border rounded px-2 py-1"
-      >
+      </Button>
+      <Button onClick={copy} className="flex items-center gap-2" variant="outline">
         <FiCopy /> Copy CSS
-      </button>
-      <button
-        onClick={reset}
-        className="flex items-center gap-2 border rounded px-2 py-1"
-      >
+      </Button>
+      <Button onClick={reset} className="flex items-center gap-2" variant="outline">
         <FiRefreshCcw /> Reset
-      </button>
+      </Button>
     </div>
   );
 }

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,0 +1,26 @@
+import { ButtonHTMLAttributes } from 'react';
+import { cn } from '../../lib/utils';
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'default' | 'outline';
+}
+
+export default function Button({
+  className,
+  variant = 'default',
+  ...props
+}: ButtonProps) {
+  const base =
+    'inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50';
+  const variants: Record<string, string> = {
+    default: 'bg-slate-900 text-white hover:bg-slate-800',
+    outline: 'border border-slate-200 hover:bg-slate-100'
+  };
+
+  return (
+    <button
+      className={cn(base, variants[variant], className)}
+      {...props}
+    />
+  );
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,3 @@
+export function cn(...classes: (string | undefined | false | null)[]): string {
+  return classes.filter(Boolean).join(' ');
+}


### PR DESCRIPTION
## Summary
- implement simplified `cn` util
- add a Shadcn-inspired Button component
- restyle ControlPanel using the new button and improved inputs

## Testing
- `pnpm run lint`
- `pnpm run test` *(fails: The package "@esbuild/linux-x64" could not be found)*